### PR TITLE
Fix invalid links to Katie Bell's speech from GoTo conference

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Ukraine is still under brutal Russian invasion. A lot of Ukrainian people are hu
 - [Freakout - Just a general outbox thing](https://github.com/rebus-org/Freakout)
 
 ### WebAssembly
-- [📺 Katie Bell - Don't Trust Anything! Real-world Uses For WebAssembly](https://www.youtube.com/watch?v=aSm8o2EIyvM)
+- [📺 Katie Bell - Don't Trust Anything! Real-world Uses For WebAssembly](https://youtu.be/zhVzWo6cdBM)
 
 ### Security
 - [Wired - Hackers Detail How They Allegedly Stole Ticketmaster Data From Snowflake](https://www.wired.com/story/epam-snowflake-ticketmaster-breach-shinyhunters/)

--- a/Summary.md
+++ b/Summary.md
@@ -3443,7 +3443,7 @@
 - [Microsoft .NET Devs Anonymously Responds to Microsoft .NET Leadership](https://pastebin.com/RF6015kv)
 
 ### WebAssembly
-- [📺 Katie Bell - Don't Trust Anything! Real-world Uses For WebAssembly](https://www.youtube.com/watch?v=aSm8o2EIyvM)
+- [📺 Katie Bell - Don't Trust Anything! Real-world Uses For WebAssembly](https://youtu.be/zhVzWo6cdBM)
 - [📺 Ryan Levick - Deconstructing WebAssembly Components](https://www.youtube.com/watch?v=zqfF7Ssa2QI)
 - [Bytecode Alliance - Announcing Jco 1.0](https://bytecodealliance.org/articles/jco-1.0)
 - [Google - WebAssembly Garbage Collection (WasmGC) now enabled by default in Chrome](https://developer.chrome.com/blog/wasmgc/)

--- a/per-week/2024-06-24.md
+++ b/per-week/2024-06-24.md
@@ -47,7 +47,7 @@ Ukraine is still under brutal Russian invasion. A lot of Ukrainian people are hu
 - [Freakout - Just a general outbox thing](https://github.com/rebus-org/Freakout)
 
 ### WebAssembly
-- [📺 Katie Bell - Don't Trust Anything! Real-world Uses For WebAssembly](https://www.youtube.com/watch?v=aSm8o2EIyvM)
+- [📺 Katie Bell - Don't Trust Anything! Real-world Uses For WebAssembly](https://youtu.be/zhVzWo6cdBM)
 
 ### Security
 - [Wired - Hackers Detail How They Allegedly Stole Ticketmaster Data From Snowflake](https://www.wired.com/story/epam-snowflake-ticketmaster-breach-shinyhunters/)


### PR DESCRIPTION
Fixes invalid YouTube link used in 24. 6. 2024 issue.